### PR TITLE
It works???

### DIFF
--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -45,6 +45,7 @@ body {
           <div class="chat-body">
 */ }
   body .app {
+    border: 10px solid black;
     align-items: center;
     background: #f0f8ff;
     display: flex;
@@ -66,10 +67,11 @@ body {
     width: 100%;
     z-index: 5; }
   body .content {
+    display: flex;
+    border: 7px solid orange;
     flex: 1 1 auto;
     height: 100%;
     width: 100%;
-    overflow-y: hidden;
     position: relative; }
   body .landing {
     width: 100%;
@@ -77,6 +79,12 @@ body {
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch; }
   body .chat {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border: 5px solid green;
     padding: 20px;
     width: 100%;
     height: 100%;
@@ -113,17 +121,14 @@ body {
     z-index: 5;
     background-color: #ffd; }
   body .chat-body {
-    width: 100%;
-    white-space: pre-wrap;
     flex: 1 1 auto;
-    height: 100%;
-    width: 100%;
     position: relative;
+    flex: 1 1 auto;
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch; }
   body .chat-input {
+    flex: 0 0 auto;
     line-height: 40px;
-    flex: 0 0 40px;
     width: 100%;
     z-index: 9; }
     body .chat-input input {

--- a/dist/index.html
+++ b/dist/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta data-react-helmet="true" name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta data-react-helmet="true" name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0"/>
     <title>Document</title>
     <link rel="stylesheet" href="css/style.css">
 </head>

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -46,6 +46,7 @@ body {
   padding: 0;
   
   .app {
+    border: 10px solid black;
     align-items: center;
     background: $back-color;
     display: flex;
@@ -70,10 +71,12 @@ body {
     z-index: 5;
   }
   .content {
+    display: flex;
+    border: 7px solid orange;
     flex: 1 1 auto;
     height: 100%;
     width: 100%;
-    overflow-y: hidden;
+    // overflow-y: hidden;
     position: relative;
   }
   .landing {
@@ -84,6 +87,13 @@ body {
   }
 
   .chat {
+    // http://stackoverflow.com/questions/33636796/chrome-safari-not-filling-100-height-of-flex-parent
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border: 5px solid green;
     padding: 20px;
     width: 100%;
     height: 100%;
@@ -136,20 +146,22 @@ body {
     background-color: #ffd;
   }
   .chat-body {
-    width: 100%;
-    white-space: pre-wrap;
-    
     flex: 1 1 auto;
-    height: 100%;
-    width: 100%;
     position: relative;
+    // width: 100%;
+    // white-space: pre-wrap;
+    //
+    flex: 1 1 auto;
+    // height: 100%;
+    // width: 100%;
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
   }
   .chat-input {
+    flex: 0 0 auto;
     //position: relative;
     line-height: 40px;
-    flex: 0 0 40px;
+    // flex: 0 0 40px;
     width: 100%;
     z-index: 9;
     


### PR DESCRIPTION
Take a look at this StackOverflow [link](http://stackoverflow.com/questions/33636796/chrome-safari-not-filling-100-height-of-flex-parent).

It seems like there's an error with nested flexbox children in Safari. Go figure... 🙄

I noticed this issue when I started putting `border` around `html`. Even though `html` had `height: 100%`, it was still overflowing the iPhone simulator screen.

From what I tested, it seems to work for mobile Safari. Are there any issues on Android?
